### PR TITLE
Sing/feat groundlevelfacility 01

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,6 +30,7 @@
     "@types/three": "^0.156.0",
     "clsx": "^2.0.0",
     "contracts": "workspace:*",
+    "ethers": "^5.7.0",
     "postprocessing": "^6.33.2",
     "pure-rand": "^6.0.4",
     "react": "^18.2.0",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -9,7 +9,11 @@ import { useMUD } from "./useMUD";
 export const App = () => {
   const {
     components: { Counter },
-    systemCalls: { mudIsPositionEmpty, mudBuildFacility },
+    systemCalls: {
+      mudIsPositionEmpty,
+      mudBuildFacility,
+      mudGetEntityMetadataAtPosition,
+    },
   } = useMUD();
 
   const counter = useComponentValue(Counter, singletonEntity);
@@ -39,6 +43,19 @@ export const App = () => {
         }}
       >
         mudIsPositionEmpty
+      </button>
+      <button
+        type="button"
+        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+        onClick={async (event) => {
+          event.preventDefault();
+          console.log(
+            "mudGetEntityMetadataAtPosition:",
+            await mudGetEntityMetadataAtPosition()
+          );
+        }}
+      >
+        mudGetEntityMetadataAtPosition
       </button>
       <LoadingScreen />
     </RootLayout>

--- a/packages/contracts/src/systems/FacilitySystem.sol
+++ b/packages/contracts/src/systems/FacilitySystem.sol
@@ -79,24 +79,6 @@ contract FacilitySystem is System {
   }
 
   /**
-   * @dev Get the ownedBy of the target entity.
-   * @param entityKey The key of the entity.
-   * @return owner address.
-   */
-  function getOwnedBy(bytes32 entityKey) public view returns (address) {
-    return OwnedBy.get(entityKey);
-  }
-
-  /**
-   * @dev Get the entityTypeId of the target entity.
-   * @param entityKey The key of the entity.
-   * @return entityTypeId.
-   */
-  function getEntityTypeId(bytes32 entityKey) public view returns (uint32) {
-    return EntityType.get(entityKey);
-  }
-
-  /**
    * @dev Build a facility of entityTypeId at the given position with the given yaw.
    * @param entityTypeId The entityTypeId of the facility to build.
    * @param x The x coordinate of the position to build the facility at.
@@ -128,7 +110,7 @@ contract FacilitySystem is System {
    */
   function destoryFacility(bytes32 entityKey) public {
     require(_msgSender() != address(0), "Invalid sender address");
-    require(getOwnedBy(entityKey) == _msgSender(), "Sender does not own this entity");
+    require(OwnedBy.get(entityKey) == _msgSender(), "Sender does not own this entity");
 
     OwnedBy.deleteRecord(entityKey);
     EntityType.deleteRecord(entityKey);

--- a/packages/contracts/src/systems/FacilitySystem.sol
+++ b/packages/contracts/src/systems/FacilitySystem.sol
@@ -105,10 +105,10 @@ contract FacilitySystem is System {
   }
 
   /**
-   * @dev Destory the facility at the given position.
-   * @param entityKey The key of the facility to destory.
+   * @dev Destroy the facility at the given position.
+   * @param entityKey The key of the facility to destroy.
    */
-  function destoryFacility(bytes32 entityKey) public {
+  function destroyFacility(bytes32 entityKey) public {
     require(_msgSender() != address(0), "Invalid sender address");
     require(OwnedBy.get(entityKey) == _msgSender(), "Sender does not own this entity");
 

--- a/packages/contracts/test/FacilitySystemTest.t.sol
+++ b/packages/contracts/test/FacilitySystemTest.t.sol
@@ -7,6 +7,7 @@ import { getKeysWithValue } from "@latticexyz/world-modules/src/modules/keyswith
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
 import { Counter, CounterTableId, Position, PositionData } from "../src/codegen/index.sol";
+import { positionToEntityKey } from "../src/positionToEntityKey.sol";
 
 contract FacilitySystemTest is MudTest {
   IWorld public world;

--- a/packages/contracts/test/FacilitySystemTest.t.sol
+++ b/packages/contracts/test/FacilitySystemTest.t.sol
@@ -72,21 +72,21 @@ contract FacilitySystemTest is MudTest {
     assertEq(posData03.x, 2);
   }
 
-  function testDestoryFacility() public {
+  function testDestroyFacility() public {
     vm.expectRevert(abi.encodePacked("Sender does not own this entity"));
-    world.destoryFacility(0);
+    world.destroyFacility(0);
 
     //build an entityTypeIdGroundLevel facility at position (1,1,1) with yaw 0
     bytes32 entityKey01 = world.buildFacility(entityTypeIdGroundLevel, 1, 0, 1, 0);
     PositionData memory posData01 = Position.get(entityKey01);
     assertEq(posData01.x, 1);
 
-    //destoryFacility should work as expected
-    world.destoryFacility(entityKey01);
+    //destroyFacility should work as expected
+    world.destroyFacility(entityKey01);
     PositionData memory posData01b = Position.get(entityKey01);
     assertNotEq(posData01b.x, 1);
 
-    //should now be able to build on the same position after the original one was destoryed
+    //should now be able to build on the same position after the original one was destroyed
     bytes32 entityKey02 = world.buildFacility(11, 1, 0, 1, 0);
     PositionData memory posData02 = Position.get(entityKey02);
     assertEq(posData02.x, 1);

--- a/packages/contracts/test/FacilitySystemTest.t.sol
+++ b/packages/contracts/test/FacilitySystemTest.t.sol
@@ -10,6 +10,8 @@ import { Counter, CounterTableId, Position, PositionData } from "../src/codegen/
 
 contract FacilitySystemTest is MudTest {
   IWorld public world;
+  uint32 public constant entityTypeIdGroundLevel = 10;
+  uint32 public constant entityTypeIdNonGroundLevel = 999;
 
   function setUp() public override {
     super.setUp();
@@ -25,18 +27,46 @@ contract FacilitySystemTest is MudTest {
     assertTrue(codeSize > 0);
   }
 
-  function testBuildFacility() public {
-    //build a facility with entityTypeId 10 at position (1,1,1) with yaw 0
-    bytes32 entityKey01 = world.buildFacility(10, 1, 1, 1, 0);
+  function testCanBuildFacilityTypeAtPosition() public {
+    //cannot build at y < 0
+    vm.expectRevert(abi.encodePacked("This facility cannot be built at this position"));
+    world.buildFacility(entityTypeIdGroundLevel, 1, -1, 1, 0);
+
+    //cannot build non ground level facility at y = 0
+    vm.expectRevert(abi.encodePacked("This facility cannot be built at this position"));
+    world.buildFacility(entityTypeIdNonGroundLevel, 1, 0, 1, 0);
+
+    //build a ground level facility at position (1,0,1) with yaw 0
+    bytes32 entityKey01 = world.buildFacility(entityTypeIdGroundLevel, 1, 0, 1, 0);
     PositionData memory posData01 = Position.get(entityKey01);
     assertEq(posData01.x, 1);
 
-    //revert if trying to build on occupied position
-    vm.expectRevert(abi.encodePacked("Position is occupied"));
-    world.buildFacility(10, 1, 1, 1, 0);
+    //cannot build on occupied position
+    vm.expectRevert(abi.encodePacked("This facility cannot be built at this position"));
+    world.buildFacility(entityTypeIdGroundLevel, 1, 0, 1, 0);
+
+    //cannot build entityTypeIdNonGroundLevel on position with nothing next to it
+    vm.expectRevert(abi.encodePacked("This facility cannot be built at this position"));
+    world.buildFacility(entityTypeIdNonGroundLevel, 3, 0, 1, 0);
+
+    //can build entityTypeIdNonGroundLevel on position with something next to it
+    bytes32 entityKey02 = world.buildFacility(entityTypeIdNonGroundLevel, 1, 1, 1, 0);
+    PositionData memory posData02 = Position.get(entityKey02);
+    assertEq(posData02.y, 1);
+  }
+
+  function testBuildFacility() public {
+    //build an entityTypeIdGroundLevel facility at position (1,1,1) with yaw 0
+    bytes32 entityKey01 = world.buildFacility(entityTypeIdGroundLevel, 1, 0, 1, 0);
+    PositionData memory posData01 = Position.get(entityKey01);
+    assertEq(posData01.x, 1);
+
+    //cannot build on occupied position
+    vm.expectRevert(abi.encodePacked("This facility cannot be built at this position"));
+    world.buildFacility(entityTypeIdGroundLevel, 1, 0, 1, 0);
 
     //should be able to build on an unoccupied position
-    bytes32 entityKey03 = world.buildFacility(10, 2, 1, 1, 0);
+    bytes32 entityKey03 = world.buildFacility(entityTypeIdGroundLevel, 2, 0, 1, 0);
     PositionData memory posData03 = Position.get(entityKey03);
     assertEq(posData03.x, 2);
   }
@@ -45,8 +75,8 @@ contract FacilitySystemTest is MudTest {
     vm.expectRevert(abi.encodePacked("Sender does not own this entity"));
     world.destoryFacility(0);
 
-    //build a facility with entityTypeId 10 at position (1,1,1) with yaw 0
-    bytes32 entityKey01 = world.buildFacility(10, 1, 1, 1, 0);
+    //build an entityTypeIdGroundLevel facility at position (1,1,1) with yaw 0
+    bytes32 entityKey01 = world.buildFacility(entityTypeIdGroundLevel, 1, 0, 1, 0);
     PositionData memory posData01 = Position.get(entityKey01);
     assertEq(posData01.x, 1);
 
@@ -56,7 +86,7 @@ contract FacilitySystemTest is MudTest {
     assertNotEq(posData01b.x, 1);
 
     //should now be able to build on the same position after the original one was destoryed
-    bytes32 entityKey02 = world.buildFacility(11, 1, 1, 1, 0);
+    bytes32 entityKey02 = world.buildFacility(11, 1, 0, 1, 0);
     PositionData memory posData02 = Position.get(entityKey02);
     assertEq(posData02.x, 1);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -116,6 +112,9 @@ importers:
       contracts:
         specifier: workspace:*
         version: link:../contracts
+      ethers:
+        specifier: ^5.7.0
+        version: 5.7.2
       postprocessing:
         specifier: ^6.33.2
         version: 6.33.2(three@0.157.0)
@@ -2382,6 +2381,7 @@ packages:
 
   /@types/node@18.18.3:
     resolution: {integrity: sha512-0OVfGupTl3NBFr8+iXpfZ8NR7jfFO+P1Q+IO/q0wbo02wYkP5gy36phojeYWpLQ6WAMjl+VfmqUk2YbUfp0irA==}
+    dev: true
 
   /@types/node@20.5.1:
     resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
@@ -2456,7 +2456,7 @@ packages:
   /@types/ws@8.5.6:
     resolution: {integrity: sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==}
     dependencies:
-      '@types/node': 18.18.3
+      '@types/node': 20.8.2
 
   /@typescript-eslint/eslint-plugin@6.7.4(@typescript-eslint/parser@6.7.4)(eslint@8.50.0)(typescript@5.2.2):
     resolution: {integrity: sha512-DAbgDXwtX+pDkAHwiGhqP3zWUGpW49B7eqmgpPtg+BKJXwdct79ut9+ifqOFPJGClGKSHXn2PTBatCnldJRUoA==}
@@ -6611,3 +6611,7 @@ packages:
     name: forge-std
     version: 1.6.0
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
contracts:
isEntityTypeIdGroundLevelFacility
  entityTypeId <= 100

canBuildFacilityTypeAtPosition
  with the ground level facility requirements implemented as discussed

unit tested

client:
  mudPositionToEntityKey
    entityKey can be calculated from position (Vector3) with this function

  mudGetEntityMetadataAtPosition
    more mud functions are exposed in createSystemCalls
    in particular this function returns all the metadata of the facility located at input position (if the facility exists)
    example output:
```
{
  "entityKey": "0x5c6090c0461491a2941743bda5c3658bf1ea53bbd3edcde54e16205e18b45792",
  "position": {
    "x": 1,
    "y": 0,
    "z": 1
  },
  "entityTypeId": {
    "typeId": 10,
    "__staticData": "0x0000000a"
  },
  "orientation": {
    "yaw": 0,
    "__staticData": "0x00000000"
  },
  "ownedBy": {
    "owner": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
    "__staticData": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
  }
}
```
    