### PR TITLE
Sing/feat mudresourcesystem 01

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,65 +1,18 @@
-import { useComponentValue } from "@latticexyz/react";
-import { singletonEntity } from "@latticexyz/store-sync/recs";
+//import { useComponentValue } from "@latticexyz/react";
+//import { singletonEntity } from "@latticexyz/store-sync/recs";
 import LoadingScreen from "@/components/loadingScreen/loadingScreen";
 
 import RootLayout from "./components/layout/layout";
 import GameRoot from "./game/gameRoot";
-import { useMUD } from "./useMUD";
+//import { useMUD } from "./useMUD";
+
+import { MudExample } from "./mudExample";
 
 export const App = () => {
-  const {
-    components: { Counter },
-    systemCalls: {
-      mudGetAllFacilityEntityMetadatas,
-      mudBuildFacility,
-      mudGetEntityMetadataAtPosition,
-    },
-  } = useMUD();
-
-  const counter = useComponentValue(Counter, singletonEntity);
-
   return (
     <RootLayout>
       <GameRoot />
-      <div>
-        Counter: <span>{counter?.value ?? "??"}</span>
-      </div>
-      <button
-        type="button"
-        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
-        onClick={async (event) => {
-          event.preventDefault();
-          console.log("mudBuildFacility:", await mudBuildFacility());
-        }}
-      >
-        mudBuildFacility
-      </button>
-      <button
-        type="button"
-        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
-        onClick={async (event) => {
-          event.preventDefault();
-          console.log(
-            "mudGetAllFacilityEntityMetadatas:",
-            await mudGetAllFacilityEntityMetadatas()
-          );
-        }}
-      >
-        mudGetAllFacilityEntityMetadatas
-      </button>
-      <button
-        type="button"
-        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
-        onClick={async (event) => {
-          event.preventDefault();
-          console.log(
-            "mudGetEntityMetadataAtPosition:",
-            await mudGetEntityMetadataAtPosition()
-          );
-        }}
-      >
-        mudGetEntityMetadataAtPosition
-      </button>
+      <MudExample />
       <LoadingScreen />
     </RootLayout>
   );

--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -294,6 +294,16 @@ export function createSystemCalls(
     return tx;
   };
 
+  const lapuVaultGetTotalSupply = async () => {
+    const gameSetting = await getComponentValue(GameSetting, singletonEntity);
+    const data = await publicClient.readContract({
+      address: gameSetting?.lapuVaultAddress,
+      abi: IERC20Abi,
+      functionName: "totalSupply",
+    });
+    return data;
+  };
+
   return {
     increment,
     mudGetEntityType,
@@ -316,5 +326,6 @@ export function createSystemCalls(
     mudDefiConsumesLapuFromPlayer,
     mudMockYieldGenerationFromDeFiPool,
     mudMockReleaseRewardToPlayer,
+    lapuVaultGetTotalSupply,
   };
 }

--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -11,6 +11,9 @@ import { ethers } from "ethers";
 import { ClientComponents } from "./createClientComponents";
 import { SetupNetworkResult } from "./setupNetwork";
 
+import IERC20Abi from "contracts/out/IERC20.sol/IERC20.abi.json";
+import ILapuVaultAbi from "contracts/out/ILapuVault.sol/ILapuVault.abi.json";
+
 export type SystemCalls = ReturnType<typeof createSystemCalls>;
 
 export function createSystemCalls(
@@ -31,8 +34,21 @@ export function createSystemCalls(
    *   through createClientComponents.ts, but it originates in
    *   syncToRecs (https://github.com/latticexyz/mud/blob/26dabb34321eedff7a43f3fcb46da4f3f5ba3708/templates/react/packages/client/src/mud/setupNetwork.ts#L39).
    */
-  { worldContract, waitForTransaction }: SetupNetworkResult,
-  { Counter, Position, Orientation, EntityType, OwnedBy }: ClientComponents
+  {
+    worldContract,
+    waitForTransaction,
+    publicClient,
+    walletClient,
+    worldAddress,
+  }: SetupNetworkResult,
+  {
+    Counter,
+    Position,
+    Orientation,
+    EntityType,
+    OwnedBy,
+    GameSetting,
+  }: ClientComponents
 ) {
   const defaultVector3 = new Vector3(1, 0, 3);
 
@@ -196,6 +212,88 @@ export function createSystemCalls(
     return res;
   };
 
+  const approveDaiToLapuVaultForTheConnectedPlayer = async (amount) => {
+    const gameSetting = await getComponentValue(GameSetting, singletonEntity);
+    const { request } = await publicClient.simulateContract({
+      address: gameSetting?.daiAddress,
+      abi: IERC20Abi,
+      functionName: "approve",
+      args: [gameSetting?.lapuVaultAddress, amount],
+      account: walletClient?.account,
+    });
+    const res = await walletClient.writeContract(request);
+    return res;
+  };
+
+  const approveLapuToMudWorldForTheConnectedPlayer = async (amount) => {
+    const gameSetting = await getComponentValue(GameSetting, singletonEntity);
+    const { request } = await publicClient.simulateContract({
+      address: gameSetting?.lapuVaultAddress,
+      abi: IERC20Abi,
+      functionName: "approve",
+      args: [worldAddress, amount],
+      account: walletClient?.account,
+    });
+    const res = await walletClient.writeContract(request);
+    return res;
+  };
+
+  const depositDaiToLapuVaultForTheConnectedPlayer = async (amount) => {
+    const gameSetting = await getComponentValue(GameSetting, singletonEntity);
+    const { request } = await publicClient.simulateContract({
+      address: gameSetting?.lapuVaultAddress,
+      abi: ILapuVaultAbi,
+      functionName: "deposit",
+      args: [amount, walletClient?.account.address],
+      account: walletClient?.account,
+    });
+    const res = await walletClient.writeContract(request);
+    return res;
+  };
+
+  const withdrawDaiFromLapuVaultForTheConnectedPlayer = async (amount) => {
+    const gameSetting = await getComponentValue(GameSetting, singletonEntity);
+    const { request } = await publicClient.simulateContract({
+      address: gameSetting?.lapuVaultAddress,
+      abi: ILapuVaultAbi,
+      functionName: "withdraw",
+      args: [
+        amount,
+        walletClient?.account.address,
+        walletClient?.account.address,
+      ],
+      account: walletClient?.account,
+    });
+    const res = await walletClient.writeContract(request);
+    return res;
+  };
+
+  const mudDefiConsumesLapuFromPlayer = async (amount, playerAddress) => {
+    const tx = await worldContract.write.defiConsumesLapuFromPlayer([
+      amount,
+      playerAddress,
+    ]);
+    await waitForTransaction(tx);
+    return tx;
+  };
+
+  const mudMockYieldGenerationFromDeFiPool = async (amount) => {
+    const tx = await worldContract.write.mockYieldGenerationFromDeFiPool([
+      amount,
+    ]);
+    await waitForTransaction(tx);
+    return tx;
+  };
+
+  const mudMockReleaseRewardToPlayer = async (playerAddress, amount) => {
+    const tx = await worldContract.write.mockReleaseRewardToPlayer([
+      playerAddress,
+      amount,
+    ]);
+    await waitForTransaction(tx);
+    return tx;
+  };
+
   return {
     increment,
     mudGetEntityType,
@@ -211,5 +309,12 @@ export function createSystemCalls(
     mudDefiDaiBalanceOf,
     mudDefiLapuBalanceOf,
     mudDefiGetTotalRewardBalance,
+    approveDaiToLapuVaultForTheConnectedPlayer,
+    approveLapuToMudWorldForTheConnectedPlayer,
+    depositDaiToLapuVaultForTheConnectedPlayer,
+    withdrawDaiFromLapuVaultForTheConnectedPlayer,
+    mudDefiConsumesLapuFromPlayer,
+    mudMockYieldGenerationFromDeFiPool,
+    mudMockReleaseRewardToPlayer,
   };
 }

--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -175,6 +175,27 @@ export function createSystemCalls(
     return allEntityMetadatas;
   };
 
+  const mudMockDaiFacuet = async (playerAddress, amount) => {
+    const tx = await worldContract.write.mockDAIFaucet(playerAddress, amount);
+    await waitForTransaction(tx);
+    return tx;
+  };
+
+  const mudDefiDaiBalanceOf = async (playerAddress) => {
+    const res = await worldContract.read.defiDaiBalanceOf(playerAddress);
+    return res;
+  };
+
+  const mudDefiLapuBalanceOf = async (playerAddress) => {
+    const res = await worldContract.read.defiLapuBalanceOf(playerAddress);
+    return res;
+  };
+
+  const mudDefiGetTotalRewardBalance = async () => {
+    const res = await worldContract.read.defiGetTotalRewardBalance();
+    return res;
+  };
+
   return {
     increment,
     mudGetEntityType,
@@ -186,5 +207,9 @@ export function createSystemCalls(
     mudBuildFacility,
     mudGetEntityMetadataAtPosition,
     mudGetAllFacilityEntityMetadatas,
+    mudMockDaiFacuet,
+    mudDefiDaiBalanceOf,
+    mudDefiLapuBalanceOf,
+    mudDefiGetTotalRewardBalance,
   };
 }

--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -34,7 +34,7 @@ export function createSystemCalls(
   { worldContract, waitForTransaction }: SetupNetworkResult,
   { Counter, Position, Orientation, EntityType, OwnedBy }: ClientComponents
 ) {
-  const defaultVector3 = new Vector3(1, 0, 1);
+  const defaultVector3 = new Vector3(1, 0, 3);
 
   const increment = async () => {
     /*
@@ -175,19 +175,19 @@ export function createSystemCalls(
     return allEntityMetadatas;
   };
 
-  const mudMockDaiFacuet = async (playerAddress, amount) => {
-    const tx = await worldContract.write.mockDAIFaucet(playerAddress, amount);
+  const mudMockDaiFaucet = async (playerAddress, amount) => {
+    const tx = await worldContract.write.mockDaiFaucet([playerAddress, amount]);
     await waitForTransaction(tx);
     return tx;
   };
 
   const mudDefiDaiBalanceOf = async (playerAddress) => {
-    const res = await worldContract.read.defiDaiBalanceOf(playerAddress);
+    const res = await worldContract.read.defiDaiBalanceOf([playerAddress]);
     return res;
   };
 
   const mudDefiLapuBalanceOf = async (playerAddress) => {
-    const res = await worldContract.read.defiLapuBalanceOf(playerAddress);
+    const res = await worldContract.read.defiLapuBalanceOf([playerAddress]);
     return res;
   };
 
@@ -207,7 +207,7 @@ export function createSystemCalls(
     mudBuildFacility,
     mudGetEntityMetadataAtPosition,
     mudGetAllFacilityEntityMetadatas,
-    mudMockDaiFacuet,
+    mudMockDaiFaucet,
     mudDefiDaiBalanceOf,
     mudDefiLapuBalanceOf,
     mudDefiGetTotalRewardBalance,

--- a/packages/client/src/mud/setupNetwork.ts
+++ b/packages/client/src/mud/setupNetwork.ts
@@ -137,5 +137,6 @@ export async function setupNetwork() {
     waitForTransaction,
     worldContract,
     write$: write$.asObservable().pipe(share()),
+    worldAddress: networkConfig.worldAddress as Hex,
   };
 }

--- a/packages/client/src/mudExample.tsx
+++ b/packages/client/src/mudExample.tsx
@@ -1,0 +1,91 @@
+import { useComponentValue } from "@latticexyz/react";
+import { singletonEntity } from "@latticexyz/store-sync/recs";
+
+import { useMUD } from "./useMUD";
+
+import { getState } from "./game/store";
+import { useState } from "react";
+
+export const MudExample = () => {
+  const {
+    components: { Counter },
+    systemCalls: {
+      mudGetAllFacilityEntityMetadatas,
+      mudBuildFacility,
+      mudGetEntityMetadataAtPosition,
+      mudDefiDaiBalanceOf,
+      mudMockDaiFaucet,
+    },
+  } = useMUD();
+
+  const counter = useComponentValue(Counter, singletonEntity);
+  const playerAddress = getState().player?.playerData?.address;
+  const [playerDaiBalance, setPlayerDaiBalance] = useState<number | null>(null);
+
+  return (
+    <div>
+      <div>
+        Player Address: <span>{playerAddress ?? "??"}</span>
+      </div>
+      <div>
+        Player DAI balance: <span>{playerDaiBalance ?? "??"}</span>
+      </div>
+      <div>
+        Counter: <span>{counter?.value ?? "??"}</span>
+      </div>
+      <button
+        type="button"
+        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+        onClick={async (event) => {
+          event.preventDefault();
+          console.log(
+            "mudMockDaiFaucet:",
+            await mudMockDaiFaucet(playerAddress, 1000)
+          );
+          const playerDaiBalance_ = (await mudDefiDaiBalanceOf(
+            playerAddress
+          )) as number;
+          setPlayerDaiBalance(playerDaiBalance_);
+        }}
+      >
+        mudMockDaiFaucet
+      </button>
+      <button
+        type="button"
+        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+        onClick={async (event) => {
+          event.preventDefault();
+          console.log("mudBuildFacility:", await mudBuildFacility());
+        }}
+      >
+        mudBuildFacility
+      </button>
+      <button
+        type="button"
+        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+        onClick={async (event) => {
+          event.preventDefault();
+          console.log(
+            "mudGetAllFacilityEntityMetadatas:",
+            await mudGetAllFacilityEntityMetadatas()
+          );
+        }}
+      >
+        mudGetAllFacilityEntityMetadatas
+      </button>
+      <button
+        type="button"
+        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+        onClick={async (event) => {
+          event.preventDefault();
+          console.log(
+            "mudGetEntityMetadataAtPosition:",
+            await mudGetEntityMetadataAtPosition()
+          );
+        }}
+      >
+        mudGetEntityMetadataAtPosition
+      </button>
+    </div>
+  );
+};

--- a/packages/client/src/mudExample.tsx
+++ b/packages/client/src/mudExample.tsx
@@ -8,7 +8,7 @@ import { useState, useEffect } from "react";
 
 export const MudExample = () => {
   const {
-    components: { Counter },
+    components: { Counter, GameSetting },
     systemCalls: {
       mudDefiDaiBalanceOf,
       mudMockDaiFaucet,
@@ -30,6 +30,7 @@ export const MudExample = () => {
   const defaultRewardAmount = 30;
 
   const counter = useComponentValue(Counter, singletonEntity);
+  const gameSetting = useComponentValue(GameSetting, singletonEntity);
   const playerAddress = getState().player?.playerData?.address;
   const [playerDaiBalance, setPlayerDaiBalance] = useState<number | null>(null);
   const [playerLapuBalance, setPlayerLapuBalance] = useState<number | null>(
@@ -98,6 +99,10 @@ export const MudExample = () => {
       <div>
         Reward balance:{" "}
         <span>{totalRewardBalance?.toString() ?? "??"} LAPU</span>
+      </div>
+      <div>
+        Total rewarded:{" "}
+        <span>{gameSetting?.totalRewarded?.toString() ?? "??"}</span>
       </div>
       <div>
         Counter: <span>{counter?.value ?? "??"}</span>

--- a/packages/client/src/mudExample.tsx
+++ b/packages/client/src/mudExample.tsx
@@ -21,6 +21,7 @@ export const MudExample = () => {
       mudDefiGetTotalRewardBalance,
       mudMockYieldGenerationFromDeFiPool,
       mudMockReleaseRewardToPlayer,
+      lapuVaultGetTotalSupply,
     },
   } = useMUD();
 
@@ -39,6 +40,7 @@ export const MudExample = () => {
   const [totalRewardBalance, setTotalRewardBalance] = useState<number | null>(
     null
   );
+  const [lapuVaultTvl, setLapuVaultTvl] = useState<bigint | null>(0);
 
   useEffect(() => {
     const refreshData = async () => {
@@ -55,6 +57,9 @@ export const MudExample = () => {
       const totalRewardBalance_ =
         (await mudDefiGetTotalRewardBalance()) as number;
       setTotalRewardBalance(totalRewardBalance_);
+
+      const lapuVaultTvl_ = (await lapuVaultGetTotalSupply()) as bigint;
+      setLapuVaultTvl(lapuVaultTvl_);
     };
 
     const refreshDataIntervalId = setInterval(refreshData, 1000);
@@ -66,6 +71,7 @@ export const MudExample = () => {
     mudDefiLapuBalanceOf,
     mudDefiGetTotalRewardBalance,
     playerAddress,
+    lapuVaultGetTotalSupply,
   ]);
 
   useEffect(() => {
@@ -97,12 +103,16 @@ export const MudExample = () => {
         <span> {playerLapuBalance?.toString() ?? "??"} LAPU</span>
       </div>
       <div>
-        Reward balance:{" "}
-        <span>{totalRewardBalance?.toString() ?? "??"} LAPU</span>
+        LAPUTA:{" "}
+        <span>
+          Reward balance {totalRewardBalance?.toString() ?? "??"} LAPU
+        </span>{" "}
+        <span>
+          Total rewarded {gameSetting?.totalRewarded?.toString() ?? "??"} LAPU
+        </span>
       </div>
       <div>
-        Total rewarded:{" "}
-        <span>{gameSetting?.totalRewarded?.toString() ?? "??"}</span>
+        LAPU VAULT TVL: <span>{lapuVaultTvl?.toString() ?? "??"} DAI</span>
       </div>
       <div>
         Counter: <span>{counter?.value ?? "??"}</span>

--- a/packages/client/src/mudExample.tsx
+++ b/packages/client/src/mudExample.tsx
@@ -4,31 +4,100 @@ import { singletonEntity } from "@latticexyz/store-sync/recs";
 import { useMUD } from "./useMUD";
 
 import { getState } from "./game/store";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export const MudExample = () => {
   const {
     components: { Counter },
     systemCalls: {
-      mudGetAllFacilityEntityMetadatas,
-      mudBuildFacility,
-      mudGetEntityMetadataAtPosition,
       mudDefiDaiBalanceOf,
       mudMockDaiFaucet,
+      approveDaiToLapuVaultForTheConnectedPlayer,
+      approveLapuToMudWorldForTheConnectedPlayer,
+      depositDaiToLapuVaultForTheConnectedPlayer,
+      withdrawDaiFromLapuVaultForTheConnectedPlayer,
+      mudDefiLapuBalanceOf,
+      mudDefiConsumesLapuFromPlayer,
+      mudDefiGetTotalRewardBalance,
+      mudMockYieldGenerationFromDeFiPool,
+      mudMockReleaseRewardToPlayer,
     },
   } = useMUD();
+
+  const defaultTestAmount = 1000;
+  const defaultConsumeAmount = 100;
+  const defaultYieldAmount = 50;
+  const defaultRewardAmount = 30;
 
   const counter = useComponentValue(Counter, singletonEntity);
   const playerAddress = getState().player?.playerData?.address;
   const [playerDaiBalance, setPlayerDaiBalance] = useState<number | null>(null);
+  const [playerLapuBalance, setPlayerLapuBalance] = useState<number | null>(
+    null
+  );
+  const [totalRewardBalance, setTotalRewardBalance] = useState<number | null>(
+    null
+  );
+
+  useEffect(() => {
+    const refreshData = async () => {
+      const playerDaiBalance_ = (await mudDefiDaiBalanceOf(
+        playerAddress
+      )) as number;
+      setPlayerDaiBalance(playerDaiBalance_);
+
+      const playerLapuBalance_ = (await mudDefiLapuBalanceOf(
+        playerAddress
+      )) as number;
+      setPlayerLapuBalance(playerLapuBalance_);
+
+      const totalRewardBalance_ =
+        (await mudDefiGetTotalRewardBalance()) as number;
+      setTotalRewardBalance(totalRewardBalance_);
+    };
+
+    const refreshDataIntervalId = setInterval(refreshData, 1000);
+    return () => {
+      clearInterval(refreshDataIntervalId);
+    };
+  }, [
+    mudDefiDaiBalanceOf,
+    mudDefiLapuBalanceOf,
+    mudDefiGetTotalRewardBalance,
+    playerAddress,
+  ]);
+
+  useEffect(() => {
+    const generateYieldIntervalId = setInterval(() => {
+      mudMockYieldGenerationFromDeFiPool(defaultYieldAmount);
+    }, 10000);
+    return () => {
+      clearInterval(generateYieldIntervalId);
+    };
+  }, [mudMockYieldGenerationFromDeFiPool]);
+
+  useEffect(() => {
+    const rewardPlayerIntervalId = setInterval(() => {
+      mudMockReleaseRewardToPlayer(playerAddress, defaultRewardAmount);
+    }, 15000);
+    return () => {
+      clearInterval(rewardPlayerIntervalId);
+    };
+  }, [playerAddress, mudMockReleaseRewardToPlayer]);
+
+  const delay = async (ms) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
 
   return (
     <div>
       <div>
-        Player Address: <span>{playerAddress ?? "??"}</span>
+        Player balance: <span>{playerDaiBalance?.toString() ?? "??"} DAI</span>{" "}
+        <span> {playerLapuBalance?.toString() ?? "??"} LAPU</span>
       </div>
       <div>
-        Player DAI balance: <span>{playerDaiBalance ?? "??"}</span>
+        Reward balance:{" "}
+        <span>{totalRewardBalance?.toString() ?? "??"} LAPU</span>
       </div>
       <div>
         Counter: <span>{counter?.value ?? "??"}</span>
@@ -40,25 +109,16 @@ export const MudExample = () => {
           event.preventDefault();
           console.log(
             "mudMockDaiFaucet:",
-            await mudMockDaiFaucet(playerAddress, 1000)
+            await mudMockDaiFaucet(playerAddress, defaultTestAmount)
           );
           const playerDaiBalance_ = (await mudDefiDaiBalanceOf(
             playerAddress
           )) as number;
+          console.log("playerDaiBalance_:", playerDaiBalance_);
           setPlayerDaiBalance(playerDaiBalance_);
         }}
       >
-        mudMockDaiFaucet
-      </button>
-      <button
-        type="button"
-        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
-        onClick={async (event) => {
-          event.preventDefault();
-          console.log("mudBuildFacility:", await mudBuildFacility());
-        }}
-      >
-        mudBuildFacility
+        getDaiFromFaucet
       </button>
       <button
         type="button"
@@ -66,12 +126,17 @@ export const MudExample = () => {
         onClick={async (event) => {
           event.preventDefault();
           console.log(
-            "mudGetAllFacilityEntityMetadatas:",
-            await mudGetAllFacilityEntityMetadatas()
+            "approveDaiToLapuVaultForTheConnectedPlayer:",
+            await approveDaiToLapuVaultForTheConnectedPlayer(defaultTestAmount)
+          );
+          await delay(1000);
+          console.log(
+            "depositDaiToLapuVaultForTheConnectedPlayer:",
+            await depositDaiToLapuVaultForTheConnectedPlayer(defaultTestAmount)
           );
         }}
       >
-        mudGetAllFacilityEntityMetadatas
+        swapDaiToLapu
       </button>
       <button
         type="button"
@@ -79,12 +144,37 @@ export const MudExample = () => {
         onClick={async (event) => {
           event.preventDefault();
           console.log(
-            "mudGetEntityMetadataAtPosition:",
-            await mudGetEntityMetadataAtPosition()
+            "approveLapuToMudWorldForTheConnectedPlayer:",
+            await approveLapuToMudWorldForTheConnectedPlayer(
+              defaultConsumeAmount
+            )
+          );
+          await delay(1000);
+          console.log(
+            "mudDefiConsumesLapuFromPlayer:",
+            await mudDefiConsumesLapuFromPlayer(
+              defaultConsumeAmount,
+              playerAddress
+            )
           );
         }}
       >
-        mudGetEntityMetadataAtPosition
+        consumeLapu
+      </button>
+      <button
+        type="button"
+        className="px-100 py-100 rounded-md border border-gray-300 bg-white text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+        onClick={async (event) => {
+          event.preventDefault();
+          console.log(
+            "withdrawDaiFromLapuVaultForTheConnectedPlayer:",
+            await withdrawDaiFromLapuVaultForTheConnectedPlayer(
+              defaultConsumeAmount
+            )
+          );
+        }}
+      >
+        swapLapuToDai
       </button>
     </div>
   );

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -13,6 +13,7 @@ export default mudConfig({
         defiPoolAddress: "address",
         daiAddress: "address",
         lapuVaultAddress: "address",
+        totalRewarded: "uint256",
       },
     },
     Position: {

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -6,6 +6,15 @@ export default mudConfig({
       keySchema: {},
       valueSchema: "uint32",
     },
+    GameSetting: {
+      keySchema: {},
+      valueSchema: {
+        aDaiAddress: "address",
+        defiPoolAddress: "address",
+        daiAddress: "address",
+        lapuVaultAddress: "address",
+      },
+    },
     Position: {
       valueSchema: {
         x: "int32",

--- a/packages/contracts/script/PostDeploy.s.sol
+++ b/packages/contracts/script/PostDeploy.s.sol
@@ -38,9 +38,6 @@ contract PostDeploy is Script {
     MockERC20 mockDAI = new MockERC20("MockDAI", "mDAI");
     console.log("mockDAI deployed at:", address(mockDAI));
 
-    // Mint some mockDAI for the world contract
-    mockDAI.faucet(worldAddress, 1000);
-
     // Deploy LapuVault
     LapuVault lapuVault = new LapuVault(
       worldAddress,
@@ -51,7 +48,12 @@ contract PostDeploy is Script {
       IERC20(address(mockAToken))
     );
     console.log("lapuVault deployed at:", address(lapuVault));
-    IWorld(worldAddress).defiAssignContractAddresses(address(mockAToken), address(mockDAI), address(lapuVault));
+    IWorld(worldAddress).defiAssignContractAddresses(
+      address(mockAToken),
+      address(mockPool),
+      address(mockDAI),
+      address(lapuVault)
+    );
 
     vm.stopBroadcast();
   }

--- a/packages/contracts/script/PostDeploy.s.sol
+++ b/packages/contracts/script/PostDeploy.s.sol
@@ -5,6 +5,15 @@ import { Script } from "forge-std/Script.sol";
 import { console } from "forge-std/console.sol";
 import { IWorld } from "../src/codegen/world/IWorld.sol";
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "../src/interfaces/IMockERC20.sol";
+import "../src/mock/MockPool.sol";
+import "../src/interfaces/IPoolAddressesProvider.sol";
+import "../src/mock/MockPoolAddressesProvider.sol";
+import "../src/mock/MockERC20.sol";
+import "../src/LapuVault.sol";
+
 contract PostDeploy is Script {
   function run(address worldAddress) external {
     // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
@@ -18,6 +27,31 @@ contract PostDeploy is Script {
     // Call increment on the world via the registered function selector
     uint32 newValue = IWorld(worldAddress).increment();
     console.log("Increment via IWorld:", newValue);
+
+    // Deploy mock tokens and mock pool
+    MockERC20 mockAToken = new MockERC20("MockAToken", "maToken");
+    console.log("mockAToken deployed at:", address(mockAToken));
+    MockPool mockPool = new MockPool(IMockERC20(mockAToken));
+    console.log("mockPool deployed at:", address(mockPool));
+    MockPoolAddressesProvider mockPoolAddressesProvider = new MockPoolAddressesProvider(address(mockPool));
+    console.log("mockPoolAddressesProvider deployed at:", address(mockPoolAddressesProvider));
+    MockERC20 mockDAI = new MockERC20("MockDAI", "mDAI");
+    console.log("mockDAI deployed at:", address(mockDAI));
+
+    // Mint some mockDAI for the world contract
+    mockDAI.faucet(worldAddress, 1000);
+
+    // Deploy LapuVault
+    LapuVault lapuVault = new LapuVault(
+      worldAddress,
+      IERC20(address(mockDAI)),
+      "LapuVault",
+      "LAPU",
+      IPoolAddressesProvider(mockPoolAddressesProvider),
+      IERC20(address(mockAToken))
+    );
+    console.log("lapuVault deployed at:", address(lapuVault));
+    IWorld(worldAddress).defiAssignContractAddresses(address(mockAToken), address(mockDAI), address(lapuVault));
 
     vm.stopBroadcast();
   }

--- a/packages/contracts/src/LapuVault.sol
+++ b/packages/contracts/src/LapuVault.sol
@@ -15,8 +15,6 @@ import "./interfaces/IPool.sol";
 contract LapuVault is Ownable, ERC4626 {
   event LAPUMintedFromDeFiYield(uint256 amount);
 
-  event LAPURewardsTransferredTo(address indexed to, uint256 amount);
-
   using Math for uint256;
 
   IPoolAddressesProvider public poolAddressProvider;
@@ -100,23 +98,12 @@ contract LapuVault is Ownable, ERC4626 {
     uint256 currentATokenBalance = aToken.balanceOf(address(this));
     if (currentATokenBalance > currentLAPUTotalShare) {
       uint256 yield = currentATokenBalance - currentLAPUTotalShare;
-      //mint the yield as new LAPU shares owned by this contract, such that they can be distributed to players as rewards at a later time
-      _mint(address(this), yield);
+      //mint the yield as new LAPU shares owned by contract owner, such that they can be distributed to players as rewards at a later time
+      _mint(owner(), yield);
       emit LAPUMintedFromDeFiYield(yield);
       return yield;
     } else {
       return 0;
     }
-  }
-
-  /**
-   * @dev emitting event LAPURewardsTransferredTo(to, amount)
-   */
-  function transferLAPURewardsTo(address to, uint256 amount) external onlyOwner {
-    require(to != address(0), "LapuVault: cannot transfer to zero address");
-    require(amount > 0, "LapuVault: cannot transfer zero amount");
-    require(amount <= balanceOf(address(this)), "LapuVault: insufficient balance");
-    _transfer(address(this), to, amount);
-    emit LAPURewardsTransferredTo(to, amount);
   }
 }

--- a/packages/contracts/src/interfaces/ILapuVault.sol
+++ b/packages/contracts/src/interfaces/ILapuVault.sol
@@ -12,10 +12,8 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import "./IPoolAddressesProvider.sol";
 import "./IPool.sol";
 
-interface ILapuVault {
+interface ILapuVault is IERC20 {
   event LAPUMintedFromDeFiYield(uint256 amount);
-
-  event LAPURewardsTransferredTo(address indexed to, uint256 amount);
 
   function convertToShares(uint256 assets) external view returns (uint256);
 
@@ -42,9 +40,4 @@ interface ILapuVault {
    * @dev emitting event LAPUMintedFromDeFiYield(yield)
    */
   function mintLAPUAccordingToDeFiYield() external returns (uint256);
-
-  /**
-   * @dev emitting event LAPURewardsTransferredTo(to, amount)
-   */
-  function transferLAPURewardsTo(address to, uint256 amount) external;
 }

--- a/packages/contracts/src/interfaces/ILapuVault.sol
+++ b/packages/contracts/src/interfaces/ILapuVault.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC4626 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC4626.sol
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+import "./IPoolAddressesProvider.sol";
+import "./IPool.sol";
+
+interface ILapuVault {
+  event LAPUMintedFromDeFiYield(uint256 amount);
+
+  event LAPURewardsTransferredTo(address indexed to, uint256 amount);
+
+  function convertToShares(uint256 assets) external view returns (uint256);
+
+  function convertToAssets(uint256 shares) external view returns (uint256);
+
+  function _convertToShares(uint256 assets, Math.Rounding rounding) external view returns (uint256);
+
+  /**
+   * @dev Internal conversion function (from shares to assets) with support for rounding direction.
+   */
+  function _convertToAssets(uint256 shares, Math.Rounding rounding) external view returns (uint256);
+
+  /**
+   * @dev emitting event Deposit(caller, receiver, assets, shares);
+   */
+  function deposit(uint256 assets, address receiver) external returns (uint256);
+
+  /**
+   * @dev emitting event Withdraw(caller, receiver, owner_, assets, shares)
+   */
+  function withdraw(uint256 assets, address receiver, address owner_) external returns (uint256);
+
+  /**
+   * @dev emitting event LAPUMintedFromDeFiYield(yield)
+   */
+  function mintLAPUAccordingToDeFiYield() external returns (uint256);
+
+  /**
+   * @dev emitting event LAPURewardsTransferredTo(to, amount)
+   */
+  function transferLAPURewardsTo(address to, uint256 amount) external;
+}

--- a/packages/contracts/src/systems/DefiSystem.sol
+++ b/packages/contracts/src/systems/DefiSystem.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.21;
+
+import { System } from "@latticexyz/world/src/System.sol";
+import { GameSetting } from "../codegen/index.sol";
+
+import "../interfaces/IMockERC20.sol";
+import "../interfaces/ILapuVault.sol";
+
+contract DefiSystem is System {
+  function defiAssignContractAddresses(
+    address aDaiAddress_,
+    address defiPoolAddress_,
+    address daiAddress_,
+    address lapuVaultAddress_
+  ) public {
+    GameSetting.setADaiAddress(aDaiAddress_);
+    GameSetting.setDefiPoolAddress(defiPoolAddress_);
+    GameSetting.setDaiAddress(daiAddress_);
+    GameSetting.setLapuVaultAddress(lapuVaultAddress_);
+  }
+
+  function defiSimulateYieldGenerationFromPool(uint256 amount) public {
+    IMockERC20 dai = IMockERC20(GameSetting.getDaiAddress());
+    IMockERC20 aDai = IMockERC20(GameSetting.getADaiAddress());
+    dai.mint(GameSetting.getDefiPoolAddress(), amount);
+    aDai.mint(GameSetting.getLapuVaultAddress(), amount);
+  }
+
+  function defiHarvestYieldToRewardPlayers() public {
+    ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
+    lapuVault.mintLAPUAccordingToDeFiYield();
+  }
+}

--- a/packages/contracts/src/systems/DefiSystem.sol
+++ b/packages/contracts/src/systems/DefiSystem.sol
@@ -4,7 +4,10 @@ pragma solidity >=0.8.21;
 import { System } from "@latticexyz/world/src/System.sol";
 import { GameSetting } from "../codegen/index.sol";
 
-import "../interfaces/IMockERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import "../interfaces/ILapuVault.sol";
 
 contract DefiSystem is System {
@@ -20,15 +23,42 @@ contract DefiSystem is System {
     GameSetting.setLapuVaultAddress(lapuVaultAddress_);
   }
 
-  function defiSimulateYieldGenerationFromPool(uint256 amount) public {
-    IMockERC20 dai = IMockERC20(GameSetting.getDaiAddress());
-    IMockERC20 aDai = IMockERC20(GameSetting.getADaiAddress());
-    dai.mint(GameSetting.getDefiPoolAddress(), amount);
-    aDai.mint(GameSetting.getLapuVaultAddress(), amount);
+  function defiDaiBalanceOf(address account) public view returns (uint256) {
+    IERC20 dai = IERC20(GameSetting.getDaiAddress());
+    return dai.balanceOf(account);
   }
 
-  function defiHarvestYieldToRewardPlayers() public {
+  function defiLapuBalanceOf(address account) public view returns (uint256) {
     ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
-    lapuVault.mintLAPUAccordingToDeFiYield();
+    return lapuVault.balanceOf(account);
+  }
+
+  function defiGetTotalRewardBalance() public view returns (uint256) {
+    // LAPU balance of this world contract = reward balance
+    ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
+    return lapuVault.balanceOf(address(this));
+  }
+
+  function defiSwapDaiToLapu(uint256 amount, address receiver) public returns (uint256) {
+    IERC20 dai = IERC20(GameSetting.getDaiAddress());
+    // transfer DAI from _msgSender to this contract first
+    SafeERC20.safeTransferFrom(IERC20(dai), _msgSender(), address(this), amount);
+
+    ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
+    // approve DAI to be deposit into lapuVault
+    dai.approve(address(lapuVault), amount);
+    return lapuVault.deposit(amount, receiver);
+  }
+
+  function defiSwapLapuToDai(uint256 amount, address receiver) public returns (uint256) {
+    ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
+    return lapuVault.withdraw(amount, receiver, _msgSender());
+  }
+
+  function defiConsumesLapuFromPlayer(uint256 amount, address consumer) public {
+    // transfer LAPU from consumer to this contract
+    // p.s. LAPU balance of this world contract = reward balance
+    ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
+    SafeERC20.safeTransferFrom(IERC20(lapuVault), consumer, address(this), amount);
   }
 }

--- a/packages/contracts/src/systems/MockSystem.sol
+++ b/packages/contracts/src/systems/MockSystem.sol
@@ -30,5 +30,7 @@ contract MockSystem is System {
   function mockReleaseRewardToPlayer(address account, uint256 amount) public {
     ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
     lapuVault.transfer(account, amount);
+    uint256 currentTotalRewarded = GameSetting.getTotalRewarded();
+    GameSetting.setTotalRewarded(currentTotalRewarded + amount);
   }
 }

--- a/packages/contracts/src/systems/MockSystem.sol
+++ b/packages/contracts/src/systems/MockSystem.sol
@@ -8,7 +8,7 @@ import "../interfaces/IMockERC20.sol";
 import "../interfaces/ILapuVault.sol";
 
 contract MockSystem is System {
-  function mockDAIFacuet(address receiver, uint256 amount) public {
+  function mockDaiFacuet(address receiver, uint256 amount) public {
     IMockERC20 dai = IMockERC20(GameSetting.getDaiAddress());
     dai.faucet(receiver, amount);
   }

--- a/packages/contracts/src/systems/MockSystem.sol
+++ b/packages/contracts/src/systems/MockSystem.sol
@@ -8,7 +8,7 @@ import "../interfaces/IMockERC20.sol";
 import "../interfaces/ILapuVault.sol";
 
 contract MockSystem is System {
-  function mockDaiFacuet(address receiver, uint256 amount) public {
+  function mockDaiFaucet(address receiver, uint256 amount) public {
     IMockERC20 dai = IMockERC20(GameSetting.getDaiAddress());
     dai.faucet(receiver, amount);
   }

--- a/packages/contracts/src/systems/MockSystem.sol
+++ b/packages/contracts/src/systems/MockSystem.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.21;
+
+import { System } from "@latticexyz/world/src/System.sol";
+import { GameSetting } from "../codegen/index.sol";
+
+import "../interfaces/IMockERC20.sol";
+import "../interfaces/ILapuVault.sol";
+
+contract MockSystem is System {
+  function mockDAIFacuet(address receiver, uint256 amount) public {
+    IMockERC20 dai = IMockERC20(GameSetting.getDaiAddress());
+    dai.faucet(receiver, amount);
+  }
+
+  function mockYieldGenerationFromDeFiPool(uint256 amount) public {
+    //mock yield generation with the increase of aToken
+    IMockERC20 dai = IMockERC20(GameSetting.getDaiAddress());
+    IMockERC20 aDai = IMockERC20(GameSetting.getADaiAddress());
+    dai.mint(GameSetting.getDefiPoolAddress(), amount);
+    aDai.mint(GameSetting.getLapuVaultAddress(), amount);
+
+    //and then mint LAPU according to the yield
+    ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
+    lapuVault.mintLAPUAccordingToDeFiYield();
+  }
+
+  //TODO: design reward distribution mechanism among players, i.e. depends on players' buildings
+  //for now, calculate the distribution off chain and use this call to distribute reward to a specific player account
+  function mockReleaseRewardToPlayer(address account, uint256 amount) public {
+    ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
+    lapuVault.transfer(account, amount);
+  }
+}

--- a/packages/contracts/test/DefiSystemtTest.t.sol
+++ b/packages/contracts/test/DefiSystemtTest.t.sol
@@ -54,7 +54,7 @@ contract DefiSystemTest is MudTest {
     assertEq(world.defiGetTotalRewardBalance(), amount02);
     vm.stopPrank();
 
-    //5. mock yield generation from DeFi pool (which we can call periodically from client)
+    //5. mock yield generation from DeFi pool (which we can call periodically call from client)
     world.mockYieldGenerationFromDeFiPool(amount03);
     assertEq(world.defiGetTotalRewardBalance(), amount02 + amount03);
 

--- a/packages/contracts/test/DefiSystemtTest.t.sol
+++ b/packages/contracts/test/DefiSystemtTest.t.sol
@@ -36,7 +36,7 @@ contract DefiSystemTest is MudTest {
     IERC20 lapu = IERC20(GameSetting.getLapuVaultAddress());
 
     //1. player get DAI from faucet
-    world.mockDaiFacuet(player01, amount01);
+    world.mockDaiFaucet(player01, amount01);
     assertEq(world.defiDaiBalanceOf(player01), amount01);
 
     vm.startPrank(player01);

--- a/packages/contracts/test/DefiSystemtTest.t.sol
+++ b/packages/contracts/test/DefiSystemtTest.t.sol
@@ -36,7 +36,7 @@ contract DefiSystemTest is MudTest {
     IERC20 lapu = IERC20(GameSetting.getLapuVaultAddress());
 
     //1. player get DAI from faucet
-    world.mockDAIFacuet(player01, amount01);
+    world.mockDaiFacuet(player01, amount01);
     assertEq(world.defiDaiBalanceOf(player01), amount01);
 
     vm.startPrank(player01);

--- a/packages/contracts/test/DefiSystemtTest.t.sol
+++ b/packages/contracts/test/DefiSystemtTest.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.21;
+
+import "forge-std/Test.sol";
+import { MudTest } from "@latticexyz/world/test/MudTest.t.sol";
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IWorld } from "../src/codegen/world/IWorld.sol";
+import { GameSetting } from "../src/codegen/index.sol";
+
+contract DefiSystemTest is MudTest {
+  IWorld public world;
+
+  function setUp() public override {
+    super.setUp();
+    world = IWorld(worldAddress);
+  }
+
+  function testWorldExists() public {
+    uint256 codeSize;
+    address addr = worldAddress;
+    assembly {
+      codeSize := extcodesize(addr)
+    }
+    assertTrue(codeSize > 0);
+  }
+
+  function testDefiSystemCycle() public {
+    address player01 = address(0x5E11E1); // random address
+    uint256 amount01 = 1000;
+    uint256 amount02 = 100;
+    uint256 amount03 = 30;
+
+    IERC20 dai = IERC20(GameSetting.getDaiAddress());
+    IERC20 lapu = IERC20(GameSetting.getLapuVaultAddress());
+
+    //1. player get DAI from faucet
+    world.mockDAIFacuet(player01, amount01);
+    assertEq(world.defiDaiBalanceOf(player01), amount01);
+
+    vm.startPrank(player01);
+    //2. player swap DAI to LAPU
+    dai.approve(address(world), amount01);
+    world.defiSwapDaiToLapu(amount01, player01);
+    assertEq(world.defiDaiBalanceOf(player01), 0);
+    assertEq(world.defiLapuBalanceOf(player01), amount01);
+
+    //3. player consume LAPU in game, i.e. for building facilities
+    lapu.approve(address(world), amount02);
+    world.defiConsumesLapuFromPlayer(amount02, player01);
+    assertEq(world.defiLapuBalanceOf(player01), amount01 - amount02);
+    //4. LAPU balance of this world contract = reward balance
+    assertEq(world.defiGetTotalRewardBalance(), amount02);
+    vm.stopPrank();
+
+    //5. mock yield generation from DeFi pool (which we can call periodically from client)
+    world.mockYieldGenerationFromDeFiPool(amount03);
+    assertEq(world.defiGetTotalRewardBalance(), amount02 + amount03);
+
+    //6. mock release reward to player
+    world.mockReleaseRewardToPlayer(player01, amount03);
+    assertEq(world.defiGetTotalRewardBalance(), amount02);
+    assertEq(world.defiLapuBalanceOf(player01), amount01 - amount02 + amount03);
+
+    vm.startPrank(player01);
+    //7. player can cash out LAPU to DAI
+    lapu.approve(address(world), amount03);
+    world.defiSwapLapuToDai(amount03, player01);
+    assertEq(world.defiLapuBalanceOf(player01), amount01 - amount02);
+    assertEq(world.defiDaiBalanceOf(player01), amount03);
+    vm.stopPrank();
+  }
+}

--- a/packages/contracts/test/LapuVaultTest.t.sol
+++ b/packages/contracts/test/LapuVaultTest.t.sol
@@ -78,11 +78,7 @@ contract LapuVaultTest is Test {
     assertEq(lapuVault.balanceOf(address(lapuVault)), 0);
     lapuVault.mintLAPUAccordingToDeFiYield();
     assertEq(lapuVault.totalSupply(), depositAmount01 + yieldAmount01);
-    assertEq(lapuVault.balanceOf(address(lapuVault)), yieldAmount01);
-
-    //call transferLAPURewardsTo to transfer rewards from vault to a player
-    lapuVault.transferLAPURewardsTo(address(this), yieldAmount01);
-    assertEq(lapuVault.balanceOf(address(lapuVault)), 0);
+    //in mintLAPUAccordingToDeFiYield, yieldAmount01 is expected to be transferred to the contract owner (this test contract)
     assertEq(lapuVault.balanceOf(address(this)), depositAmount01 + yieldAmount01);
 
     //player withdraws deposit and yield


### PR DESCRIPTION
[partial work]
Integration of DeFi yield + LAPU vault + mud is now done.
Here is the implemented cycle of using LAPU as a resource

    1. player get DAI from faucet
    world.mockDaiFacuet(player01, amount01);

    2. player swap DAI to LAPU
    dai.approve(address(world), amount01);
    world.defiSwapDaiToLapu(amount01, player01);

    3. player consume LAPU in game, i.e. for building facilities
    lapu.approve(address(world), amount02);
    world.defiConsumesLapuFromPlayer(amount02, player01);

    4. LAPU balance of this world contract = reward balance

    5. mock yield generation from DeFi pool (which we can call periodically from client)
    world.mockYieldGenerationFromDeFiPool(amount03);

    6. mock release reward to player
    world.mockReleaseRewardToPlayer(player01, amount03);
    //TODO: design reward distribution mechanism among players, i.e. depends on players' buildings
    //for now, calculate the distribution off chain and use this call to distribute reward to a specific player account

    7. player can cash out LAPU to DAI
    lapu.approve(address(world), amount03);
    world.defiSwapLapuToDai(amount03, player01);

I am in the middle of exposing all these functions in createSystemCalls.ts. Will finish that tomorrow.