### PR TITLE
Sing/feat mudresourcesystem 02

### DIFF
--- a/packages/client/src/components/ui/tutorialModal.tsx
+++ b/packages/client/src/components/ui/tutorialModal.tsx
@@ -4,6 +4,8 @@ import { getState } from "@/game/store";
 import { useState, useEffect } from "react";
 import { useSpring, animated, config } from "@react-spring/web";
 
+import { useMUD } from "@/useMUD";
+
 function TutorialModal({
   step,
   screenIndex,
@@ -75,6 +77,11 @@ function TutorialModal({
 }
 
 const Tutorial = () => {
+  const {
+    systemCalls: { mockLapuVaultFundPlayer },
+  } = useMUD();
+  const playerAddress = getState().player?.playerData?.address;
+
   const [currentTutorial, setCurrentTutorial] = useState<
     TutorialStep | undefined
   >(undefined);
@@ -119,6 +126,8 @@ const Tutorial = () => {
             } else {
               setScreenIndex(screenIndex + 1);
             }
+
+            mockLapuVaultFundPlayer(playerAddress);
           }}
         />
       )}

--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -240,6 +240,11 @@ export function createSystemCalls(
 
   const depositDaiToLapuVaultForTheConnectedPlayer = async (amount) => {
     const gameSetting = await getComponentValue(GameSetting, singletonEntity);
+    console.log("gameSetting?.lapuVaultAddress", gameSetting?.lapuVaultAddress);
+    console.log(
+      "depositDaiToLapuVaultForTheConnectedPlayer walletClient?.account.address",
+      walletClient?.account.address
+    );
     const { request } = await publicClient.simulateContract({
       address: gameSetting?.lapuVaultAddress,
       abi: ILapuVaultAbi,
@@ -304,6 +309,16 @@ export function createSystemCalls(
     return data;
   };
 
+  const mockLapuVaultFundPlayer = async (playerAddress, amount = 1000) => {
+    console.log("mockLapuVaultFundPlayer start", playerAddress, amount);
+    await mudMockDaiFaucet(playerAddress, amount);
+    console.log("mudMockDaiFaucet done");
+    await approveDaiToLapuVaultForTheConnectedPlayer(amount);
+    console.log("approveDaiToLapuVaultForTheConnectedPlayer done");
+    await depositDaiToLapuVaultForTheConnectedPlayer(amount);
+    console.log("mockLapuVaultFundPlayer done", playerAddress, amount);
+  };
+
   return {
     increment,
     mudGetEntityType,
@@ -327,5 +342,6 @@ export function createSystemCalls(
     mudMockYieldGenerationFromDeFiPool,
     mudMockReleaseRewardToPlayer,
     lapuVaultGetTotalSupply,
+    mockLapuVaultFundPlayer,
   };
 }

--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -48,9 +48,14 @@ export function createSystemCalls(
     EntityType,
     OwnedBy,
     GameSetting,
+    EntityTypeDetail,
   }: ClientComponents
 ) {
   const defaultVector3 = new Vector3(1, 0, 3);
+
+  const delay = async (ms) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
 
   const increment = async () => {
     /*
@@ -92,6 +97,14 @@ export function createSystemCalls(
     return res;
   };
 
+  const mudGetLapuBuildingCost = async (entityTypeId: number) => {
+    const entityTypeDetail = await getComponentValue(
+      EntityTypeDetail,
+      entityTypeId
+    );
+    return entityTypeDetail?.buildingCostLapu || 400;
+  };
+
   const mudBuildFacility = async (
     entityTypeId: number = 10,
     x: number = defaultVector3.x,
@@ -101,6 +114,18 @@ export function createSystemCalls(
     color: string = "#ff00ff",
     variant: number = 0
   ) => {
+    //approve mud world to spend LAPU for building
+    const buildingCostLapu = await mudGetLapuBuildingCost(entityTypeId);
+    console.log(
+      "mudBuildFacility approveLapuToMudWorldForTheConnectedPlayer",
+      buildingCostLapu
+    );
+    await approveLapuToMudWorldForTheConnectedPlayer(buildingCostLapu);
+    console.log(
+      "mudBuildFacility approveLapuToMudWorldForTheConnectedPlayer done"
+    );
+
+    delay(1000);
     const tx = await worldContract.write.buildFacility([
       entityTypeId,
       x,
@@ -222,7 +247,10 @@ export function createSystemCalls(
       account: walletClient?.account,
     });
     const res = await walletClient.writeContract(request);
-    return res;
+    const transaction = await publicClient.waitForTransactionReceipt({
+      hash: res,
+    });
+    return transaction;
   };
 
   const approveLapuToMudWorldForTheConnectedPlayer = async (amount) => {
@@ -235,7 +263,10 @@ export function createSystemCalls(
       account: walletClient?.account,
     });
     const res = await walletClient.writeContract(request);
-    return res;
+    const transaction = await publicClient.waitForTransactionReceipt({
+      hash: res,
+    });
+    return transaction;
   };
 
   const depositDaiToLapuVaultForTheConnectedPlayer = async (amount) => {
@@ -253,7 +284,10 @@ export function createSystemCalls(
       account: walletClient?.account,
     });
     const res = await walletClient.writeContract(request);
-    return res;
+    const transaction = await publicClient.waitForTransactionReceipt({
+      hash: res,
+    });
+    return transaction;
   };
 
   const withdrawDaiFromLapuVaultForTheConnectedPlayer = async (amount) => {
@@ -270,7 +304,10 @@ export function createSystemCalls(
       account: walletClient?.account,
     });
     const res = await walletClient.writeContract(request);
-    return res;
+    const transaction = await publicClient.waitForTransactionReceipt({
+      hash: res,
+    });
+    return transaction;
   };
 
   const mudDefiConsumesLapuFromPlayer = async (amount, playerAddress) => {
@@ -283,6 +320,7 @@ export function createSystemCalls(
   };
 
   const mudMockYieldGenerationFromDeFiPool = async (amount) => {
+    console.log("mudMockYieldGenerationFromDeFiPool", amount);
     const tx = await worldContract.write.mockYieldGenerationFromDeFiPool([
       amount,
     ]);
@@ -313,10 +351,19 @@ export function createSystemCalls(
     console.log("mockLapuVaultFundPlayer start", playerAddress, amount);
     await mudMockDaiFaucet(playerAddress, amount);
     console.log("mudMockDaiFaucet done");
+    delay(1000);
     await approveDaiToLapuVaultForTheConnectedPlayer(amount);
     console.log("approveDaiToLapuVaultForTheConnectedPlayer done");
+    delay(1000);
     await depositDaiToLapuVaultForTheConnectedPlayer(amount);
     console.log("mockLapuVaultFundPlayer done", playerAddress, amount);
+  };
+
+  const mudDefiDistributeRewardsToPlayers = async () => {
+    console.log("mudDefiDistributeRewardsToPlayers");
+    const tx = await worldContract.write.defiDistributeRewardsToPlayers();
+    await waitForTransaction(tx);
+    return tx;
   };
 
   return {
@@ -343,5 +390,6 @@ export function createSystemCalls(
     mudMockReleaseRewardToPlayer,
     lapuVaultGetTotalSupply,
     mockLapuVaultFundPlayer,
+    mudDefiDistributeRewardsToPlayers,
   };
 }

--- a/packages/client/src/mudExample.tsx
+++ b/packages/client/src/mudExample.tsx
@@ -19,16 +19,16 @@ export const MudExample = () => {
       mudDefiLapuBalanceOf,
       mudDefiConsumesLapuFromPlayer,
       mudDefiGetTotalRewardBalance,
-      mudMockYieldGenerationFromDeFiPool,
-      mudMockReleaseRewardToPlayer,
+      //mudMockYieldGenerationFromDeFiPool,
+      //mudMockReleaseRewardToPlayer,
       lapuVaultGetTotalSupply,
     },
   } = useMUD();
 
   const defaultTestAmount = 1000;
   const defaultConsumeAmount = 100;
-  const defaultYieldAmount = 50;
-  const defaultRewardAmount = 30;
+  //const defaultYieldAmount = 50;
+  //const defaultRewardAmount = 30;
 
   const counter = useComponentValue(Counter, singletonEntity);
   const gameSetting = useComponentValue(GameSetting, singletonEntity);
@@ -74,6 +74,7 @@ export const MudExample = () => {
     lapuVaultGetTotalSupply,
   ]);
 
+  /*
   useEffect(() => {
     const generateYieldIntervalId = setInterval(() => {
       mudMockYieldGenerationFromDeFiPool(defaultYieldAmount);
@@ -91,6 +92,7 @@ export const MudExample = () => {
       clearInterval(rewardPlayerIntervalId);
     };
   }, [playerAddress, mudMockReleaseRewardToPlayer]);
+  */
 
   const delay = async (ms) => {
     return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/client/src/mudExample.tsx
+++ b/packages/client/src/mudExample.tsx
@@ -27,6 +27,7 @@ export const MudExample = () => {
   const defaultTestAmount = 1000;
   const defaultConsumeAmount = 400;
   const defaultYieldAmount = 50;
+  const backgroundTxIntervalTime = 20000;
 
   const counter = useComponentValue(Counter, singletonEntity);
   const gameSetting = useComponentValue(GameSetting, singletonEntity);
@@ -88,7 +89,7 @@ export const MudExample = () => {
       if (backgroundTxEnabled) {
         executeBackgroundTx();
       }
-    }, 30000);
+    }, backgroundTxIntervalTime);
     return () => {
       clearInterval(backgroundTxIntervalId);
     };

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -46,7 +46,7 @@ export default mudConfig({
       },
       valueSchema: {
         buildingCostLapu: "uint256",
-        isResidence: "bool",
+        residence: "uint256",
       },
     },
     PlayerDataDetail: {

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -13,6 +13,7 @@ export default mudConfig({
         defiPoolAddress: "address",
         daiAddress: "address",
         lapuVaultAddress: "address",
+        totalResidence: "uint256",
         totalRewarded: "uint256",
       },
     },
@@ -39,6 +40,24 @@ export default mudConfig({
         typeId: "uint32",
       },
     },
+    EntityTypeDetail: {
+      keySchema: {
+        entityTypeId: "uint32",
+      },
+      valueSchema: {
+        buildingCostLapu: "uint256",
+        isResidence: "bool",
+      },
+    },
+    PlayerDataDetail: {
+      keySchema: {
+        playerId: "address",
+      },
+      valueSchema: {
+        residence: "uint256",
+        rewarded: "uint256",
+      },
+    },
     OwnedBy: {
       valueSchema: {
         owner: "address",
@@ -49,7 +68,7 @@ export default mudConfig({
     {
       name: "KeysInTableModule",
       root: true,
-      args: [resolveTableId("Position")],
+      args: [resolveTableId("Position"), resolveTableId("PlayerDataDetail")],
     },
     {
       name: "KeysWithValueModule",

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -50,9 +50,6 @@ export default mudConfig({
       },
     },
     PlayerDataDetail: {
-      keySchema: {
-        playerId: "address",
-      },
       valueSchema: {
         residence: "uint256",
         rewarded: "uint256",
@@ -68,12 +65,17 @@ export default mudConfig({
     {
       name: "KeysInTableModule",
       root: true,
-      args: [resolveTableId("Position"), resolveTableId("PlayerDataDetail")],
+      args: [resolveTableId("Position")],
     },
     {
       name: "KeysWithValueModule",
       root: true,
       args: [resolveTableId("Position")],
+    },
+    {
+      name: "KeysInTableModule",
+      root: true,
+      args: [resolveTableId("PlayerDataDetail")],
     },
   ],
 });

--- a/packages/contracts/script/PostDeploy.s.sol
+++ b/packages/contracts/script/PostDeploy.s.sol
@@ -55,6 +55,8 @@ contract PostDeploy is Script {
       address(lapuVault)
     );
 
+    IWorld(worldAddress).facilitySystemSetupEntityTypeDetails();
+
     vm.stopBroadcast();
   }
 }

--- a/packages/contracts/src/systems/FacilitySystem.sol
+++ b/packages/contracts/src/systems/FacilitySystem.sol
@@ -75,8 +75,7 @@ contract FacilitySystem is System {
     bytes32 playerKey = bytes32(bytes20(player));
     if (residence > 0) {
       GameSetting.setTotalResidence(GameSetting.getTotalResidence() + residence);
-      //PlayerDataDetail.setResidence(playerKey, PlayerDataDetail.getResidence(playerKey) + residence);
-      PlayerDataDetail.set(playerKey, 1, 0);
+      PlayerDataDetail.setResidence(playerKey, PlayerDataDetail.getResidence(playerKey) + residence);
     }
   }
 

--- a/packages/contracts/src/systems/FacilitySystem.sol
+++ b/packages/contracts/src/systems/FacilitySystem.sol
@@ -72,17 +72,20 @@ contract FacilitySystem is System {
 
   function updatePlayerDataDetailForBuildingFacilityType(address player, uint32 entityTypeId) public {
     uint256 residence = EntityTypeDetail.getResidence(entityTypeId);
+    bytes32 playerKey = bytes32(bytes20(player));
     if (residence > 0) {
       GameSetting.setTotalResidence(GameSetting.getTotalResidence() + residence);
-      PlayerDataDetail.setResidence(player, PlayerDataDetail.getResidence(player) + residence);
+      //PlayerDataDetail.setResidence(playerKey, PlayerDataDetail.getResidence(playerKey) + residence);
+      PlayerDataDetail.set(playerKey, 1, 0);
     }
   }
 
   function updatePlayerDataDetailForDestroyFacilityType(address player, uint32 entityTypeId) public {
     uint256 residence = EntityTypeDetail.getResidence(entityTypeId);
+    bytes32 playerKey = bytes32(bytes20(player));
     if (residence > 0) {
       GameSetting.setTotalResidence(GameSetting.getTotalResidence() - residence);
-      PlayerDataDetail.setResidence(player, PlayerDataDetail.getResidence(player) - residence);
+      PlayerDataDetail.setResidence(playerKey, PlayerDataDetail.getResidence(playerKey) - residence);
     }
   }
 

--- a/packages/contracts/src/systems/MockSystem.sol
+++ b/packages/contracts/src/systems/MockSystem.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.21;
 
 import { System } from "@latticexyz/world/src/System.sol";
-import { GameSetting } from "../codegen/index.sol";
+import { GameSetting, PlayerDataDetail } from "../codegen/index.sol";
 
 import "../interfaces/IMockERC20.sol";
 import "../interfaces/ILapuVault.sol";
@@ -30,7 +30,8 @@ contract MockSystem is System {
   function mockReleaseRewardToPlayer(address account, uint256 amount) public {
     ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
     lapuVault.transfer(account, amount);
-    uint256 currentTotalRewarded = GameSetting.getTotalRewarded();
-    GameSetting.setTotalRewarded(currentTotalRewarded + amount);
+    bytes32 accountKey = bytes32(bytes20(account));
+    PlayerDataDetail.setRewarded(accountKey, PlayerDataDetail.getRewarded(accountKey) + amount);
+    GameSetting.setTotalRewarded(GameSetting.getTotalRewarded() + amount);
   }
 }

--- a/packages/contracts/test/DefiSystemtTest.t.sol
+++ b/packages/contracts/test/DefiSystemtTest.t.sol
@@ -7,10 +7,12 @@ import { MudTest } from "@latticexyz/world/test/MudTest.t.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
-import { GameSetting } from "../src/codegen/index.sol";
+import { GameSetting, PlayerDataDetail } from "../src/codegen/index.sol";
 
 contract DefiSystemTest is MudTest {
   IWorld public world;
+  uint32 public constant entityTypeIdGroundLevel = 1;
+  uint32 public constant entityTypeIdResidence = 103;
 
   function setUp() public override {
     super.setUp();
@@ -28,8 +30,9 @@ contract DefiSystemTest is MudTest {
 
   function testDefiSystemCycle() public {
     address player01 = address(0x5E11E1); // random address
+    bytes32 player01Key = bytes32(bytes20(player01));
     uint256 amount01 = 1000;
-    uint256 amount02 = 100;
+    uint256 amount02 = 475;
     uint256 amount03 = 30;
 
     IERC20 dai = IERC20(GameSetting.getDaiAddress());
@@ -46,28 +49,33 @@ contract DefiSystemTest is MudTest {
     assertEq(world.defiDaiBalanceOf(player01), 0);
     assertEq(world.defiLapuBalanceOf(player01), amount01);
 
-    //3. player consume LAPU in game, i.e. for building facilities
-    lapu.approve(address(world), amount02);
-    world.defiConsumesLapuFromPlayer(amount02, player01);
+    //3. player build facility and consume LAPU in game
+    vm.startPrank(player01);
+    lapu.approve(address(world), amount01);
+    world.buildFacility(entityTypeIdGroundLevel, 1, 0, 1, 0, "#ffffff", 0);
+    world.buildFacility(entityTypeIdResidence, 1, 1, 1, 0, "#ffffff", 0);
+    vm.stopPrank();
     assertEq(world.defiLapuBalanceOf(player01), amount01 - amount02);
+    assertEq(GameSetting.getTotalResidence(), 1);
+    assertEq(PlayerDataDetail.getResidence(player01Key), 1);
+
     //4. LAPU balance of this world contract = reward balance
     assertEq(world.defiGetTotalRewardBalance(), amount02);
-    vm.stopPrank();
 
     //5. mock yield generation from DeFi pool (which we can call periodically call from client)
     world.mockYieldGenerationFromDeFiPool(amount03);
     assertEq(world.defiGetTotalRewardBalance(), amount02 + amount03);
 
-    //6. mock release reward to player
-    world.mockReleaseRewardToPlayer(player01, amount03);
-    assertEq(world.defiGetTotalRewardBalance(), amount02);
-    assertEq(world.defiLapuBalanceOf(player01), amount01 - amount02 + amount03);
+    //6. release rewards to players
+    world.defiDistributeRewardsToPlayers();
+    assertEq(world.defiGetTotalRewardBalance(), 0);
+    assertEq(world.defiLapuBalanceOf(player01), amount01 + amount03);
 
     vm.startPrank(player01);
     //7. player can cash out LAPU to DAI
     lapu.approve(address(world), amount03);
     world.defiSwapLapuToDai(amount03, player01);
-    assertEq(world.defiLapuBalanceOf(player01), amount01 - amount02);
+    assertEq(world.defiLapuBalanceOf(player01), amount01);
     assertEq(world.defiDaiBalanceOf(player01), amount03);
     vm.stopPrank();
   }

--- a/packages/contracts/test/FacilitySystemTest.t.sol
+++ b/packages/contracts/test/FacilitySystemTest.t.sol
@@ -6,17 +6,32 @@ import { MudTest } from "@latticexyz/world/test/MudTest.t.sol";
 import { getKeysWithValue } from "@latticexyz/world-modules/src/modules/keyswithvalue/getKeysWithValue.sol";
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
-import { Counter, CounterTableId, Position, PositionData } from "../src/codegen/index.sol";
+import { Counter, CounterTableId, Position, PositionData, GameSetting } from "../src/codegen/index.sol";
 import { positionToEntityKey } from "../src/positionToEntityKey.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../src/interfaces/IMockERC20.sol";
+import "../src/interfaces/ILapuVault.sol";
 
 contract FacilitySystemTest is MudTest {
   IWorld public world;
   uint32 public constant entityTypeIdGroundLevel = 10;
   uint32 public constant entityTypeIdNonGroundLevel = 999;
 
+  //address player01 = address(0x5E11E1); // random address
+
   function setUp() public override {
     super.setUp();
     world = IWorld(worldAddress);
+
+    //fund this contract with 1000 LAPU and approve it to be spent
+    //vm.startPrank(player01);
+    IMockERC20 dai = IMockERC20(GameSetting.getDaiAddress());
+    dai.faucet(address(this), 1000);
+    ILapuVault lapuVault = ILapuVault(GameSetting.getLapuVaultAddress());
+    IERC20(address(dai)).approve(address(lapuVault), 1000);
+    lapuVault.deposit(1000, address(this));
+    IERC20(address(lapuVault)).approve(address(world), 1000);
+    //vm.stopPrank();
   }
 
   function testWorldExists() public {

--- a/packages/contracts/worlds.json
+++ b/packages/contracts/worlds.json
@@ -1,7 +1,7 @@
 {
   "4242": {
-    "address": "0xceF3b131C2568231907d8Ce5D592773642bB60ed",
-    "blockNumber": 28118760
+    "address": "0x79A093E913C12bee8099232aDcF9F445a2f074fF",
+    "blockNumber": 28247102
   },
   "31337": {
     "address": "0x5FbDB2315678afecb367f032d93F642f64180aa3"


### PR DESCRIPTION
1. upon mudBuildFacility, LAPU is required and will be consumed (from player to reward pool), enforced onchain.
entitytypeID
1 = 400
102 = 300
103 = 75
104 = 50
else default: 100

2. mudDefiDistributeRewardsToPlayers will distributed rewards to all players according to their total residence count all processed and tracked on chain.

3. mockLapuVaultFundPlayer will fund the player with 1000 LAPU for each call. It is called on every press of the tutorial next button.
It can also be triggered by a "FundPlayer" button hidden at the bottom of the game screen, reach by down arrow button.

4. executeBackgroundTx is disabled by default. It can be enabled by the hidden button at the bottom of the game screen, reach by the down arrow button.
It would interval at 20sec (change if needed) alternative between mudMockYieldGenerationFromDeFiPool and mudDefiDistributeRewardsToPlayers 